### PR TITLE
HUD is drawn in screen coordinates (Closes #70)

### DIFF
--- a/devices/generic_hud_device.h
+++ b/devices/generic_hud_device.h
@@ -27,44 +27,60 @@ public:
             std::bind(&GenericHudDevice::hndPlayerVelocity, this, _1));
         bus_->Subscribe(db_PlayerThrust,
             std::bind(&GenericHudDevice::hndPlayerThrust, this, _1));
+
+        DISPLAY.GetSize(scr_width_, scr_height_);
+        hud_position_x_ = scr_width_ >> 1;
+        hud_position_y_ = scr_height_ >> 1;
+        hud_size_ = scr_height_ * 0.3;
+        big_marker_size_ = 0.02 * scr_height_;
+        small_marker_size_ = 0.01 * scr_height_;
+        vector_scale_ = 0.01 * scr_height_;
     }
     void Render() {
         glPushMatrix();
         glLoadIdentity();
+
+        glTranslated(hud_position_x_, hud_position_y_, 0);
+        glScaled(1.0, -1.0, 1.0);
         glRotated(pa, 0.0, 0.0, -1.0);
 
         // HUD Circle
-        const double size = 8.0;
         glLineWidth(4.0);
         glColor4f(0.4, 1.0, 0.4, 0.5);
         glBegin(GL_LINE_LOOP);
         for (double a = 0.0; a < 2.0 * M_PI; a+=0.1) {
-            glVertex2d(size * cos(a), size * sin(a));
+            glVertex2d(hud_size_ * cos(a), hud_size_ * sin(a));
         }
         glEnd();
-        glLineWidth(8.0);
+
+        // HUD Markers - Big
+        glLineWidth(10.0);
         glBegin(GL_LINES);
-            glVertex2d(0.0, size+0.05);
-            glVertex2d(0.0, size+0.4);
+            glVertex2i(0.0, hud_size_ + 1);
+            glVertex2i(0.0, hud_size_ + big_marker_size_);
         glEnd();
-        glLineWidth(2.0);
+        // HUD Markers - Small
+        glLineWidth(4.0);
         glBegin(GL_LINES);
-            glVertex2d(0.0, -size-0.05);
-            glVertex2d(0.0, -size-0.25);
-            glVertex2d(-size-0.05, 0.0);
-            glVertex2d(-size-0.25, 0.0);
-            glVertex2d(size+0.05, 0.0);
-            glVertex2d(size+0.25, 0.0);
+            glVertex2i(0.0, -hud_size_ - small_marker_size_);
+            glVertex2i(0.0, -hud_size_ - 1);
+            glVertex2i(-hud_size_ - 1, 0.0);
+            glVertex2i(-hud_size_ - small_marker_size_, 0.0);
+            glVertex2i(hud_size_ + small_marker_size_, 0.0);
+            glVertex2i(hud_size_ + 1, 0.0);
         glEnd();
 
+        glPushMatrix();
+        glScaled(vector_scale_, vector_scale_, 1.0);
+        glLineWidth(2.0);
         // Thrust  : green
         glColor3f(0.0, 1.0, 0.0);
         glBegin(GL_LINES);
             glVertex2d(0.0, 0.0);
-            glVertex2d(0.25 * tx, 0.25 * ty);
+            glVertex2d(tx, ty);
         glEnd();
         // Gravity : yellow
-        glColor3f(1.0, 1.0, 0.0);
+        glColor3f(1.0, 0.5, 0.0);
         glBegin(GL_LINES);
             glVertex2d(0.0, 0.0);
             glVertex2d(gx, gy);
@@ -75,6 +91,7 @@ public:
             glVertex2d(0.0, 0.0);
             glVertex2d(vx, vy);
         glEnd();
+        glPopMatrix();
 
         glPopMatrix();
     }
@@ -113,6 +130,14 @@ private:
     double gx, gy;
     double tx, ty;
     double vx, vy;
+    int scr_width_;
+    int scr_height_;
+    int hud_position_x_;
+    int hud_position_y_;
+    int hud_size_;
+    int big_marker_size_;
+    int small_marker_size_;
+    int vector_scale_;
 };
 
 #endif // GENERIC_HUD_DEVICE_H_

--- a/game_play.h
+++ b/game_play.h
@@ -54,6 +54,7 @@ public:
 
         glPopMatrix();
 
+        DISPLAY.UiMode();
         RenderHUD();
     }
     GameDefinitions::GameStateEnum KeyInput(int key, bool action) {


### PR DESCRIPTION
- HUD dimensions defined in screen coordinates (%30 of height),
- Vector lengths, also scaled proportional with screen height,
- Gravity vector color changed from yellow to orange, for better visibility.