### PR TITLE
Thrust is published by engine (Closes #116)

### DIFF
--- a/systems/engine_system_interface.h
+++ b/systems/engine_system_interface.h
@@ -25,9 +25,8 @@ public:
     virtual double DumpFuel(double value) = 0;
     virtual double FuelQuery() = 0;
     virtual double FuelVolume() = 0;
-// Output handlers
-    virtual void ThrustOutputHandler(std::function<void(double)> thrustOut) = 0;
-    virtual void MomentOutputHandler(std::function<void(double)> momentOut) = 0;
+
+    virtual void Mount(b2Body *body) = 0;
 
 // Standard ship system interface
     virtual void Init(DataBus* bus) {


### PR DESCRIPTION
- Effects (there are only for engine) moved into BasicEngineSystem.
- Thrust stuff moved into Engine class.
- Thrust output handlers removed from SpaceShip.
- Publishing thrust for hud moved into engine.
- Thrust handler registration removed, physical body mounting added to engine interface.
- UpdateThrust not called event based, but continuously.