### PR TITLE
Planet access refactored

### DIFF
--- a/inc/SolarSystemInterface.h
+++ b/inc/SolarSystemInterface.h
@@ -3,6 +3,11 @@
 
 #include <Box2D.h>
 
+#include <vector>
+#include <memory>
+
+class Planet;
+
 class SolarSystemInterface {
 public:
     virtual ~SolarSystemInterface() {}
@@ -10,6 +15,7 @@ public:
     virtual void Render() = 0;
     virtual void Update(double time_step) = 0;
     virtual b2Vec2 GetGravityAcceleration(b2Vec2 pos) = 0;
+    virtual std::vector<std::shared_ptr<Planet>> GetPlanets() = 0;
 };
 
 #endif // SOLAR_SYSTEM_INTERFACE_H_

--- a/inc/TestingSystem.h
+++ b/inc/TestingSystem.h
@@ -5,6 +5,9 @@
 
 #include <Box2D.h>
 
+#include <vector>
+#include <memory>
+
 class Planet;
 
 class TestingSystem : public SolarSystemInterface {
@@ -15,11 +18,10 @@ public:
     void Init(b2World * world);
     void Update(double delta_time);
     void Render();
+    std::vector<std::shared_ptr<Planet>> GetPlanets();
 
 private:
-    const int kNumPlanets;
-    Planet * planets_;
-
+    std::vector<std::shared_ptr<Planet>> planets_;
 };
 
 #endif // TESTING_SYSTEM_H_

--- a/systems/inc/BasicRadarMk1.h
+++ b/systems/inc/BasicRadarMk1.h
@@ -3,6 +3,9 @@
 
 #include "ShipSystemBase.h"
 
+#include <vector>
+#include <memory>
+
 class DataBus;
 class DataBusConnection;
 class Planet;
@@ -18,11 +21,9 @@ public:
     void dbHandleShipPosition(BusDataInterface *data);
 
 private:
-    int num_planets_;
-    Planet* planets_;
+    std::vector<std::shared_ptr<Planet>> planets_;
     double plr_x_;
     double plr_y_;
 };
 
 #endif // BASIC_RADAR_MK1_H_
-


### PR DESCRIPTION
  * A new method implemented in SolarSystemInterface to return planets.
  * A vector used in testing system to store planets.
  * planets & nplanets removed from object manager.
  * Basic radar now uses "solar" object to access planets.